### PR TITLE
Update serverName logic for improved Realm support

### DIFF
--- a/src/main/java/com/mamiyaotaru/voxelmap/WaypointManager.java
+++ b/src/main/java/com/mamiyaotaru/voxelmap/WaypointManager.java
@@ -199,7 +199,7 @@ public class WaypointManager {
                 boolean isOnLAN = serverData.isLocal();
                 boolean isRealm = VoxelConstants.isRealmServer();
                 if (isOnLAN || isRealm) {
-                    VoxelConstants.getLogger().error("LAN or Realm server detected!");
+                    VoxelConstants.getLogger().warn("LAN or Realm server detected!");
                     serverName = serverData.name;
                 } else {
                     serverName = serverData.address;

--- a/src/main/java/com/mamiyaotaru/voxelmap/WaypointManager.java
+++ b/src/main/java/com/mamiyaotaru/voxelmap/WaypointManager.java
@@ -197,13 +197,15 @@ public class WaypointManager {
             ServerInfo serverData = VoxelConstants.getMinecraft().getCurrentServerEntry();
             if (serverData != null) {
                 boolean isOnLAN = serverData.isLocal();
-                if (isOnLAN) {
-                    VoxelConstants.getLogger().warn("LAN server detected!");
+                boolean isRealm = VoxelConstants.isRealmServer();
+                if (isOnLAN || isRealm) {
+                    VoxelConstants.getLogger().error("LAN or Realm server detected!");
                     serverName = serverData.name;
                 } else {
                     serverName = serverData.address;
                 }
             } else if (VoxelConstants.isRealmServer()) {
+                VoxelConstants.getLogger().warn("ServerData was null, and detected as realm server.");
                 Session session = VoxelConstants.getMinecraft().getSession();
                 serverName = session.getSessionId();
                 VoxelConstants.getLogger().info(serverName);

--- a/src/main/java/com/mamiyaotaru/voxelmap/WaypointManager.java
+++ b/src/main/java/com/mamiyaotaru/voxelmap/WaypointManager.java
@@ -12,12 +12,16 @@ import com.mamiyaotaru.voxelmap.util.OpenGL;
 import com.mamiyaotaru.voxelmap.util.TextUtils;
 import com.mamiyaotaru.voxelmap.util.Waypoint;
 import com.mamiyaotaru.voxelmap.util.WaypointContainer;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ServerInfo;
 import net.minecraft.client.session.Session;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
+import net.minecraft.client.realms.RealmsClient;
+import net.minecraft.client.realms.dto.RealmsServer;
+import net.minecraft.client.realms.dto.RealmsServerList;
 import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.WorldSavePath;
@@ -198,9 +202,19 @@ public class WaypointManager {
             if (serverData != null) {
                 boolean isOnLAN = serverData.isLocal();
                 boolean isRealm = VoxelConstants.isRealmServer();
-                if (isOnLAN || isRealm) {
-                    VoxelConstants.getLogger().warn("LAN or Realm server detected!");
+                if (isOnLAN) {
+                    VoxelConstants.getLogger().warn("LAN server detected!");
                     serverName = serverData.name;
+                } else if (isRealm) {
+                    VoxelConstants.getLogger().info("Server is a Realm.");
+                    RealmsClient realmsClient = RealmsClient.createRealmsClient(MinecraftClient.getInstance());
+                    RealmsServerList realmsServerList = realmsClient.listWorlds();
+                    for (RealmsServer realmsServer : realmsServerList.servers) {
+                        if (realmsServer.name.equals(serverData.name)) {
+                            serverName = "Realm_" + realmsServer.id + "." + realmsServer.ownerUUID;
+                            break;
+                        }
+                    }
                 } else {
                     serverName = serverData.address;
                 }


### PR DESCRIPTION
Fixes server detection for Realm servers by using a combination of the Realm ID + Realm Owner UUID. 

Some things to note:
- Before, it would hit L204/L218 and use serverData.address for Realms as serverData does not seem to be null. 
- I left in the else statement that checks isRealmServer() if serverData is null. Though serverData was never null for me across 2 Realms and multiple game restarts.
- I have not adjusted the `mod_version` in this PR.