### PR TITLE
Modern Minecraft GUI for VoxelMap (And Waypoint Improvements)

### DIFF
--- a/common/src/main/java/com/mamiyaotaru/voxelmap/MapSettingsManager.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/MapSettingsManager.java
@@ -63,6 +63,8 @@ public class MapSettingsManager implements ISettingsManager {
 
     public boolean moveMapDownWhileStatusEffect = true;
     public boolean moveScoreBoardDown = true;
+    public boolean distanceUnitConversion = true;
+    public boolean waypointNameBelowIcon = true;
     public int sort = 1;
     protected boolean realTimeTorches;
     public final KeyMapping keyBindZoom = new KeyMapping("key.minimap.zoom", InputConstants.getKey("key.keyboard.z").getValue(), "controls.minimap.title");
@@ -136,6 +138,8 @@ public class MapSettingsManager implements ISettingsManager {
                         case "Teleport Command" -> this.teleportCommand = curLine[1];
                         case "Move Map Down While Status Effect" -> this.moveMapDownWhileStatusEffect = Boolean.parseBoolean(curLine[1]);
                         case "Move ScoreBoard Down" -> this.moveScoreBoardDown = Boolean.parseBoolean(curLine[1]);
+                        case "Distance Unit Conversion" -> this.distanceUnitConversion = Boolean.parseBoolean(curLine[1]);
+                        case "Waypoint Name Below Icon" -> this.waypointNameBelowIcon = Boolean.parseBoolean(curLine[1]);
                     }
                 }
 
@@ -208,6 +212,8 @@ public class MapSettingsManager implements ISettingsManager {
             out.println("Teleport Command:" + this.teleportCommand);
             out.println("Move Map Down While Status Effect:" + this.moveMapDownWhileStatusEffect);
             out.println("Move ScoreBoard Down:" + this.moveScoreBoardDown);
+            out.println("Distance Unit Conversion:" + this.distanceUnitConversion);
+            out.println("Waypoint Name Below Icon:" + this.waypointNameBelowIcon);
 
             for (ISubSettingsManager subSettingsManager : this.subSettingsManagers) {
                 subSettingsManager.saveAll(out);
@@ -270,6 +276,8 @@ public class MapSettingsManager implements ISettingsManager {
             case WORLDBORDER -> this.worldborder;
             case MOVEMAPDOWNWHILESTATSUEFFECT -> this.moveMapDownWhileStatusEffect;
             case MOVESCOREBOARDDOWN -> this.moveScoreBoardDown;
+            case DISTANCEUNITCONVERSION -> this.distanceUnitConversion;
+            case WAYPOINTNAMEBELOWICON -> this.waypointNameBelowIcon;
             default -> throw new IllegalArgumentException("Add code to handle EnumOptionMinimap: " + par1EnumOptions.getName() + ". (possibly not a boolean applicable to minimap)");
         };
     }
@@ -394,6 +402,8 @@ public class MapSettingsManager implements ISettingsManager {
             case WORLDBORDER -> this.worldborder = !this.worldborder;
             case MOVEMAPDOWNWHILESTATSUEFFECT -> this.moveMapDownWhileStatusEffect = !this.moveMapDownWhileStatusEffect;
             case MOVESCOREBOARDDOWN -> this.moveScoreBoardDown = !this.moveScoreBoardDown;
+            case DISTANCEUNITCONVERSION -> this.distanceUnitConversion = !this.distanceUnitConversion;
+            case WAYPOINTNAMEBELOWICON -> this.waypointNameBelowIcon = !this.waypointNameBelowIcon;
             case TERRAIN -> {
                 if (this.slopemap && this.heightmap) {
                     this.slopemap = false;

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/MapSettingsManager.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/MapSettingsManager.java
@@ -65,6 +65,7 @@ public class MapSettingsManager implements ISettingsManager {
     public boolean moveScoreBoardDown = true;
     public boolean distanceUnitConversion = true;
     public boolean waypointNameBelowIcon = true;
+    public boolean waypointDistanceBelowName = true;
     public int sort = 1;
     protected boolean realTimeTorches;
     public final KeyMapping keyBindZoom = new KeyMapping("key.minimap.zoom", InputConstants.getKey("key.keyboard.z").getValue(), "controls.minimap.title");
@@ -140,6 +141,7 @@ public class MapSettingsManager implements ISettingsManager {
                         case "Move ScoreBoard Down" -> this.moveScoreBoardDown = Boolean.parseBoolean(curLine[1]);
                         case "Distance Unit Conversion" -> this.distanceUnitConversion = Boolean.parseBoolean(curLine[1]);
                         case "Waypoint Name Below Icon" -> this.waypointNameBelowIcon = Boolean.parseBoolean(curLine[1]);
+                        case "Waypoint Distance Below Name" -> this.waypointDistanceBelowName  = Boolean.parseBoolean(curLine[1]);
                     }
                 }
 
@@ -214,6 +216,7 @@ public class MapSettingsManager implements ISettingsManager {
             out.println("Move ScoreBoard Down:" + this.moveScoreBoardDown);
             out.println("Distance Unit Conversion:" + this.distanceUnitConversion);
             out.println("Waypoint Name Below Icon:" + this.waypointNameBelowIcon);
+            out.println("Waypoint Distance Below Name:" + this.waypointDistanceBelowName);
 
             for (ISubSettingsManager subSettingsManager : this.subSettingsManagers) {
                 subSettingsManager.saveAll(out);
@@ -278,6 +281,7 @@ public class MapSettingsManager implements ISettingsManager {
             case MOVESCOREBOARDDOWN -> this.moveScoreBoardDown;
             case DISTANCEUNITCONVERSION -> this.distanceUnitConversion;
             case WAYPOINTNAMEBELOWICON -> this.waypointNameBelowIcon;
+            case WAYPOINTDISTANCEBELOWNAME -> this.waypointDistanceBelowName;
             default -> throw new IllegalArgumentException("Add code to handle EnumOptionMinimap: " + par1EnumOptions.getName() + ". (possibly not a boolean applicable to minimap)");
         };
     }
@@ -404,6 +408,7 @@ public class MapSettingsManager implements ISettingsManager {
             case MOVESCOREBOARDDOWN -> this.moveScoreBoardDown = !this.moveScoreBoardDown;
             case DISTANCEUNITCONVERSION -> this.distanceUnitConversion = !this.distanceUnitConversion;
             case WAYPOINTNAMEBELOWICON -> this.waypointNameBelowIcon = !this.waypointNameBelowIcon;
+            case WAYPOINTDISTANCEBELOWNAME -> this.waypointDistanceBelowName = !this.waypointDistanceBelowName;
             case TERRAIN -> {
                 if (this.slopemap && this.heightmap) {
                     this.slopemap = false;

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/VoxelConstants.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/VoxelConstants.java
@@ -27,6 +27,8 @@ public final class VoxelConstants {
     private static final VoxelMap VOXELMAP_INSTANCE = new VoxelMap();
     private static int elapsedTicks;
     private static final ResourceLocation OPTIONS_BACKGROUND_TEXTURE = ResourceLocation.parse("textures/block/dirt.png");
+    private static final ResourceLocation OPTIONS_SEPARATOR_HEADER = ResourceLocation.parse("textures/gui/inworld_header_separator.png");
+    private static final ResourceLocation OPTIONS_SEPARATOR_FOOTER = ResourceLocation.parse("textures/gui/inworld_footer_separator.png");
     public static final boolean DEBUG = false;
     private static boolean initialized;
     private static Events events;
@@ -85,6 +87,12 @@ public final class VoxelConstants {
 
     public static ResourceLocation getOptionsBackgroundTexture() {
         return OPTIONS_BACKGROUND_TEXTURE;
+    }
+    public static ResourceLocation getOptionsSeparatorHeader() {
+        return OPTIONS_SEPARATOR_HEADER;
+    }
+    public static ResourceLocation getOptionsSeparatorFooter() {
+        return OPTIONS_SEPARATOR_FOOTER;
     }
 
     public static void lateInit() {

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiAddWaypoint.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiAddWaypoint.java
@@ -38,8 +38,8 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
     private Component tooltip;
     private EditBox waypointName;
     private EditBox waypointX;
-    private EditBox waypointZ;
     private EditBox waypointY;
+    private EditBox waypointZ;
     private PopupGuiButton buttonEnabled;
     protected final Waypoint waypoint;
     private boolean choosingColor;
@@ -76,16 +76,16 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
         this.waypointX = new EditBox(this.getFontRenderer(), this.getWidth() / 2 - 100, this.getHeight() / 6 + 41 + 13, 56, 20, null);
         this.waypointX.setMaxLength(128);
         this.waypointX.setValue(String.valueOf(this.waypoint.getX()));
-        this.waypointZ = new EditBox(this.getFontRenderer(), this.getWidth() / 2 - 28, this.getHeight() / 6 + 41 + 13, 56, 20, null);
-        this.waypointZ.setMaxLength(128);
-        this.waypointZ.setValue(String.valueOf(this.waypoint.getZ()));
-        this.waypointY = new EditBox(this.getFontRenderer(), this.getWidth() / 2 + 44, this.getHeight() / 6 + 41 + 13, 56, 20, null);
+        this.waypointY = new EditBox(this.getFontRenderer(), this.getWidth() / 2 - 28, this.getHeight() / 6 + 41 + 13, 56, 20, null);
         this.waypointY.setMaxLength(128);
         this.waypointY.setValue(String.valueOf(this.waypoint.getY()));
+        this.waypointZ = new EditBox(this.getFontRenderer(), this.getWidth() / 2 + 44, this.getHeight() / 6 + 41 + 13, 56, 20, null);
+        this.waypointZ.setMaxLength(128);
+        this.waypointZ.setValue(String.valueOf(this.waypoint.getZ()));
         this.addRenderableWidget(this.waypointName);
         this.addRenderableWidget(this.waypointX);
-        this.addRenderableWidget(this.waypointZ);
         this.addRenderableWidget(this.waypointY);
+        this.addRenderableWidget(this.waypointZ);
         int buttonListY = this.getHeight() / 6 + 82 + 6;
         this.addRenderableWidget(this.buttonEnabled = new PopupGuiButton(this.getWidth() / 2 - 101, buttonListY, 100, 20, Component.literal("Enabled: " + (this.waypoint.enabled ? "On" : "Off")), button -> this.waypoint.enabled = !this.waypoint.enabled, this));
         this.addRenderableWidget(new PopupGuiButton(this.getWidth() / 2 - 101, buttonListY + 24, 100, 20, Component.literal(I18n.get("minimap.waypoints.sortbycolor") + ":     "), button -> this.choosingColor = true, this));
@@ -122,8 +122,8 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
     protected void acceptWaypoint() {
         waypoint.name = waypointName.getValue();
         waypoint.setX(Integer.parseInt(waypointX.getValue()));
-        waypoint.setZ(Integer.parseInt(waypointZ.getValue()));
         waypoint.setY(Integer.parseInt(waypointY.getValue()));
+        waypoint.setZ(Integer.parseInt(waypointZ.getValue()));
 
         if (parentGui != null) {
             parentGui.accept(true);
@@ -151,8 +151,8 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
 
             try {
                 Integer.parseInt(this.waypointX.getValue());
-                Integer.parseInt(this.waypointZ.getValue());
                 Integer.parseInt(this.waypointY.getValue());
+                Integer.parseInt(this.waypointZ.getValue());
             } catch (NumberFormatException var7) {
                 acceptable = false;
             }
@@ -175,8 +175,8 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
 
             try {
                 Integer.parseInt(this.waypointX.getValue());
-                Integer.parseInt(this.waypointZ.getValue());
                 Integer.parseInt(this.waypointY.getValue());
+                Integer.parseInt(this.waypointZ.getValue());
             } catch (NumberFormatException var6) {
                 acceptable = false;
             }
@@ -193,8 +193,8 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
             super.mouseClicked(mouseX, mouseY, button);
             this.waypointName.mouseClicked(mouseX, mouseY, button);
             this.waypointX.mouseClicked(mouseX, mouseY, button);
-            this.waypointZ.mouseClicked(mouseX, mouseY, button);
             this.waypointY.mouseClicked(mouseX, mouseY, button);
+            this.waypointZ.mouseClicked(mouseX, mouseY, button);
         } else if (this.choosingColor) {
             if (mouseX >= (this.getWidth() / 2f - 128) && mouseX < (this.getWidth() / 2f + 128) && mouseY >= (this.getHeight() / 2f - 128) && mouseY < (this.getHeight() / 2f + 128)) {
                 int color = this.colorManager.getColorPicker().getRGB((int) mouseX - (this.getWidth() / 2 - 128), (int) mouseY - (this.getHeight() / 2 - 128));
@@ -282,15 +282,16 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
         this.tooltip = null;
         this.buttonEnabled.setMessage(Component.literal(I18n.get("minimap.waypoints.enabled") + " " + (this.waypoint.enabled ? I18n.get("options.on") : I18n.get("options.off"))));
         if (!this.choosingColor && !this.choosingIcon) {
-            this.renderTransparentBackground(drawContext);
+            this.renderBlurredBackground();
+            this.renderMenuBackground(drawContext);
             drawContext.flush();
         }
 
         drawContext.drawCenteredString(this.getFontRenderer(), (this.parentGui == null || !this.parentGui.isEditing()) && !this.editing ? I18n.get("minimap.waypoints.new") : I18n.get("minimap.waypoints.edit"), this.getWidth() / 2, 20, 16777215);
-        drawContext.drawString(this.getFontRenderer(), I18n.get("minimap.waypoints.name"), this.getWidth() / 2 - 100, this.getHeight() / 6, 10526880);
-        drawContext.drawString(this.getFontRenderer(), I18n.get("X"), this.getWidth() / 2 - 100, this.getHeight() / 6 + 41, 10526880);
-        drawContext.drawString(this.getFontRenderer(), I18n.get("Z"), this.getWidth() / 2 - 28, this.getHeight() / 6 + 41, 10526880);
-        drawContext.drawString(this.getFontRenderer(), I18n.get("Y"), this.getWidth() / 2 + 44, this.getHeight() / 6 + 41, 10526880);
+        drawContext.drawString(this.getFontRenderer(), I18n.get("minimap.waypoints.name"), this.getWidth() / 2 - 100, this.getHeight() / 6, 16777215);
+        drawContext.drawString(this.getFontRenderer(), I18n.get("X"), this.getWidth() / 2 - 100, this.getHeight() / 6 + 41, 16777215);
+        drawContext.drawString(this.getFontRenderer(), I18n.get("Y"), this.getWidth() / 2 - 28, this.getHeight() / 6 + 41, 16777215);
+        drawContext.drawString(this.getFontRenderer(), I18n.get("Z"), this.getWidth() / 2 + 44, this.getHeight() / 6 + 41, 16777215);
         int buttonListY = this.getHeight() / 6 + 82 + 6;
         super.render(drawContext, this.choosingColor || this.choosingIcon ? 0 : mouseX, this.choosingColor || this.choosingIcon ? 0 : mouseY, delta);
         RenderSystem.setShaderColor(this.waypoint.red, this.waypoint.green, this.waypoint.blue, 1.0F);
@@ -303,7 +304,8 @@ public class GuiAddWaypoint extends GuiScreenMinimap implements IPopupGuiScreen 
         this.drawTexturedModalRect((this.getWidth() / 2f - 25), (buttonListY + 48 + 2), icon, 16.0F, 16.0F);
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         if (this.choosingColor || this.choosingIcon) {
-            this.renderTransparentBackground(drawContext);
+            this.renderBlurredBackground();
+            this.renderMenuBackground(drawContext);
             drawContext.flush();
         }
 

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiMinimapControls.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiMinimapControls.java
@@ -75,7 +75,8 @@ public class GuiMinimapControls extends GuiScreenMinimap {
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-        this.renderTransparentBackground(drawContext);
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         drawContext.flush();
         drawContext.drawCenteredString(this.getFontRenderer(), this.screenTitle, this.getWidth() / 2, 20, 16777215);
         int leftBorder = this.getLeftBorder();

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiMinimapPerformance.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiMinimapPerformance.java
@@ -144,7 +144,8 @@ public class GuiMinimapPerformance extends GuiScreenMinimap {
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-        this.renderTransparentBackground(drawContext);
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         drawContext.flush();
         drawContext.drawCenteredString(this.getFontRenderer(), this.screenTitle, this.getWidth() / 2, 20, 16777215);
         super.render(drawContext, mouseX, mouseY, delta);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiMobs.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiMobs.java
@@ -128,6 +128,8 @@ public class GuiMobs extends GuiScreenMinimap {
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         this.tooltip = null;
         this.mobsList.render(drawContext, mouseX, mouseY, delta);
         drawContext.drawCenteredString(this.getFontRenderer(), this.screenTitle, this.getWidth() / 2, 20, 16777215);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiRadarOptions.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiRadarOptions.java
@@ -12,8 +12,8 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
 public class GuiRadarOptions extends GuiScreenMinimap {
-    private static final EnumOptionsMinimap[] FULL_RELEVANT_OPTIONS = { EnumOptionsMinimap.SHOWRADAR, EnumOptionsMinimap.RADARMODE, EnumOptionsMinimap.SHOWHOSTILES, EnumOptionsMinimap.SHOWNEUTRALS, EnumOptionsMinimap.SHOWPLAYERS, EnumOptionsMinimap.SHOWPLAYERNAMES, EnumOptionsMinimap.SHOWMOBNAMES, EnumOptionsMinimap.SHOWPLAYERHELMETS, EnumOptionsMinimap.SHOWMOBHELMETS, EnumOptionsMinimap.RADARFILTERING, EnumOptionsMinimap.RADAROUTLINES };
-    private static final EnumOptionsMinimap[] SIMPLE_RELEVANT_OPTIONS = { EnumOptionsMinimap.SHOWRADAR, EnumOptionsMinimap.RADARMODE, EnumOptionsMinimap.SHOWHOSTILES, EnumOptionsMinimap.SHOWNEUTRALS, EnumOptionsMinimap.SHOWPLAYERS, EnumOptionsMinimap.SHOWFACING };
+    private static final EnumOptionsMinimap[] FULL_RELEVANT_OPTIONS = { EnumOptionsMinimap.SHOWRADAR, EnumOptionsMinimap.RADARMODE,  EnumOptionsMinimap.SHOWNEUTRALS, EnumOptionsMinimap.SHOWHOSTILES, EnumOptionsMinimap.SHOWPLAYERS, EnumOptionsMinimap.SHOWMOBNAMES, EnumOptionsMinimap.SHOWPLAYERNAMES, EnumOptionsMinimap.SHOWMOBHELMETS, EnumOptionsMinimap.SHOWPLAYERHELMETS, EnumOptionsMinimap.RADARFILTERING, EnumOptionsMinimap.RADAROUTLINES };
+    private static final EnumOptionsMinimap[] SIMPLE_RELEVANT_OPTIONS = { EnumOptionsMinimap.SHOWRADAR, EnumOptionsMinimap.RADARMODE, EnumOptionsMinimap.SHOWNEUTRALS, EnumOptionsMinimap.SHOWHOSTILES, EnumOptionsMinimap.SHOWPLAYERS, EnumOptionsMinimap.SHOWFACING };
 
     private final Screen parent;
     private final RadarSettingsManager options;
@@ -42,7 +42,7 @@ public class GuiRadarOptions extends GuiScreenMinimap {
 
         iterateButtonOptions();
 
-        if (options.radarMode == 2) addRenderableWidget(new Button.Builder(Component.translatable("options.minimap.radar.selectmobs"), x -> VoxelConstants.getMinecraft().setScreen(new GuiMobs(this, options))).bounds(getWidth() / 2 - 155, getHeight() / 6 + 144 - 6, 150, 20).build());
+        if (options.radarMode == 2) addRenderableWidget(new Button.Builder(Component.translatable("options.minimap.radar.selectmobs"), x -> VoxelConstants.getMinecraft().setScreen(new GuiMobs(this, options))).bounds(getWidth() / 2 + 5, getHeight() / 6 + 120, 150, 20).build());
 
         addRenderableWidget(new Button.Builder(Component.translatable("gui.done"), x -> VoxelConstants.getMinecraft().setScreen(parent)).bounds(getWidth() / 2 - 100, getHeight() / 6 + 168, 200, 20).build());
     }
@@ -64,7 +64,8 @@ public class GuiRadarOptions extends GuiScreenMinimap {
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-        renderTransparentBackground(drawContext);
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         drawContext.flush();
         drawContext.drawCenteredString(getFontRenderer(), screenTitle, getWidth() / 2, 20, 16777215);
 

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiSelectPlayer.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiSelectPlayer.java
@@ -120,6 +120,8 @@ public class GuiSelectPlayer extends GuiScreenMinimap implements BooleanConsumer
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         renderBackgroundTexture(drawContext);
         this.tooltip = null;
         this.playerList.render(drawContext, mouseX, mouseY, delta);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiSubworldEdit.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiSubworldEdit.java
@@ -112,7 +112,8 @@ public class GuiSubworldEdit extends GuiScreenMinimap implements BooleanConsumer
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-        this.renderTransparentBackground(drawContext);
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         drawContext.flush();
         drawContext.drawCenteredString(this.getFontRenderer(), Component.translatable("worldmap.subworld.edit"), this.getWidth() / 2, 20, 16777215);
         drawContext.drawString(this.getFontRenderer(), Component.translatable("worldmap.subworld.name"), this.getWidth() / 2 - 100, this.getHeight() / 6, 10526880);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypoints.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypoints.java
@@ -67,12 +67,12 @@ public class GuiWaypoints extends GuiScreenMinimap implements IGuiWaypoints {
         this.filter = new EditBox(this.getFontRenderer(), this.getWidth() / 2 - 153 + filterStringWidth + 5, this.getHeight() - 80, 305 - filterStringWidth - 5, 20, null);
         this.filter.setMaxLength(35);
         this.addRenderableWidget(this.filter);
-        this.addRenderableWidget(this.buttonEdit = new Button.Builder(Component.translatable("selectServer.edit"), button -> this.editWaypoint(this.selectedWaypoint)).bounds(this.getWidth() / 2 - 154, this.getHeight() - 52, 74, 20).build());
-        this.addRenderableWidget(this.buttonDelete = new Button.Builder(Component.translatable("selectServer.delete"), button -> this.deleteClicked()).bounds(this.getWidth() / 2 - 76, this.getHeight() - 52, 74, 20).build());
-        this.addRenderableWidget(this.buttonHighlight = new Button.Builder(Component.translatable("minimap.waypoints.highlight"), button -> this.setHighlightedWaypoint()).bounds(this.getWidth() / 2 + 2, this.getHeight() - 52, 74, 20).build());
-        this.addRenderableWidget(this.buttonTeleport = new Button.Builder(Component.translatable("minimap.waypoints.teleportto"), button -> this.teleportClicked()).bounds(this.getWidth() / 2 + 80, this.getHeight() - 52, 74, 20).build());
-        this.addRenderableWidget(this.buttonShare = new Button.Builder(Component.translatable("minimap.waypoints.share"), button -> CommandUtils.sendWaypoint(this.selectedWaypoint)).bounds(this.getWidth() / 2 - 154, this.getHeight() - 28, 74, 20).build());
-        this.addRenderableWidget(new Button.Builder(Component.translatable("minimap.waypoints.newwaypoint"), button -> this.addWaypoint()).bounds(this.getWidth() / 2 - 76, this.getHeight() - 28, 74, 20).build());
+        this.addRenderableWidget(new Button.Builder(Component.translatable("minimap.waypoints.add"), button -> this.addWaypoint()).bounds(this.getWidth() / 2 - 154, this.getHeight() - 52, 74, 20).build());
+        this.addRenderableWidget(this.buttonEdit = new Button.Builder(Component.translatable("selectServer.edit"), button -> this.editWaypoint(this.selectedWaypoint)).bounds(this.getWidth() / 2 - 76, this.getHeight() - 52, 74, 20).build());
+        this.addRenderableWidget(this.buttonDelete = new Button.Builder(Component.translatable("selectServer.delete"), button -> this.deleteClicked()).bounds(this.getWidth() / 2 + 2, this.getHeight() - 52, 74, 20).build());
+        this.addRenderableWidget(this.buttonHighlight = new Button.Builder(Component.translatable("minimap.waypoints.highlight"), button -> this.setHighlightedWaypoint()).bounds(this.getWidth() / 2 + 80, this.getHeight() - 52, 74, 20).build());
+        this.addRenderableWidget(this.buttonTeleport = new Button.Builder(Component.translatable("minimap.waypoints.teleportto"), button -> this.teleportClicked()).bounds(this.getWidth() / 2 - 154, this.getHeight() - 28, 74, 20).build());
+        this.addRenderableWidget(this.buttonShare = new Button.Builder(Component.translatable("minimap.waypoints.share"), button -> CommandUtils.sendWaypoint(this.selectedWaypoint)).bounds(this.getWidth() / 2 - 76, this.getHeight() - 28, 74, 20).build());
         this.addRenderableWidget(new Button.Builder(Component.translatable("menu.options"), button -> VoxelConstants.getMinecraft().setScreen(new GuiWaypointsOptions(this, this.options))).bounds(this.getWidth() / 2 + 2, this.getHeight() - 28, 74, 20).build());
         this.addRenderableWidget(new Button.Builder(Component.translatable("gui.done"), button -> VoxelConstants.getMinecraft().setScreen(this.parentScreen)).bounds(this.getWidth() / 2 + 80, this.getHeight() - 28, 74, 20).build());
         this.setFocused(this.filter);
@@ -267,6 +267,8 @@ public class GuiWaypoints extends GuiScreenMinimap implements IGuiWaypoints {
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         this.tooltip = null;
         this.waypointList.render(drawContext, mouseX, mouseY, delta);
         drawContext.drawCenteredString(this.getFontRenderer(), this.screenTitle, this.getWidth() / 2, 20, 16777215);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypointsOptions.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypointsOptions.java
@@ -12,7 +12,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
 public class GuiWaypointsOptions extends GuiScreenMinimap {
-    private static final EnumOptionsMinimap[] relevantOptions = { EnumOptionsMinimap.WAYPOINTDISTANCE, EnumOptionsMinimap.DEATHPOINTS };
+    private static final EnumOptionsMinimap[] relevantOptions = { EnumOptionsMinimap.WAYPOINTDISTANCE, EnumOptionsMinimap.DISTANCEUNITCONVERSION, EnumOptionsMinimap.DEATHPOINTS, EnumOptionsMinimap.WAYPOINTNAMEBELOWICON };
     private final Screen parent;
     private final MapSettingsManager options;
     protected Component screenTitle;

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypointsOptions.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypointsOptions.java
@@ -53,7 +53,8 @@ public class GuiWaypointsOptions extends GuiScreenMinimap {
     }
 
     public void render(GuiGraphics drawContext, int mouseX, int mouseY, float delta) {
-        this.renderTransparentBackground(drawContext);
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         drawContext.flush();
         drawContext.drawCenteredString(this.font, this.screenTitle, this.getWidth() / 2, 20, 16777215);
         super.render(drawContext, mouseX, mouseY, delta);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypointsOptions.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/GuiWaypointsOptions.java
@@ -12,7 +12,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
 public class GuiWaypointsOptions extends GuiScreenMinimap {
-    private static final EnumOptionsMinimap[] relevantOptions = { EnumOptionsMinimap.WAYPOINTDISTANCE, EnumOptionsMinimap.DISTANCEUNITCONVERSION, EnumOptionsMinimap.DEATHPOINTS, EnumOptionsMinimap.WAYPOINTNAMEBELOWICON };
+    private static final EnumOptionsMinimap[] relevantOptions = { EnumOptionsMinimap.WAYPOINTDISTANCE, EnumOptionsMinimap.DISTANCEUNITCONVERSION, EnumOptionsMinimap.WAYPOINTNAMEBELOWICON, EnumOptionsMinimap.WAYPOINTDISTANCEBELOWNAME, EnumOptionsMinimap.DEATHPOINTS};
     private final Screen parent;
     private final MapSettingsManager options;
     protected Component screenTitle;

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/EnumOptionsMinimap.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/EnumOptionsMinimap.java
@@ -44,7 +44,8 @@ public enum EnumOptionsMinimap {
     MOVEMAPDOWNWHILESTATSUEFFECT("options.minimap.movemapdownwhilestatuseffect", false, true, false),
     MOVESCOREBOARDDOWN("options.minimap.movescoreboarddown", false, true, false),
     DISTANCEUNITCONVERSION("options.minimap.waypoints.distanceunitconversion", false, true, false),
-    WAYPOINTNAMEBELOWICON("options.minimap.waypoints.waypointnamebelowicon", false, true, false);
+    WAYPOINTNAMEBELOWICON("options.minimap.waypoints.waypointnamebelowicon", false, true, false),
+    WAYPOINTDISTANCEBELOWNAME("options.minimap.waypoints.waypointdistancebelowname", false, true, false);
 
     private final boolean isFloat;
     private final boolean isBoolean;

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/EnumOptionsMinimap.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/EnumOptionsMinimap.java
@@ -42,7 +42,9 @@ public enum EnumOptionsMinimap {
     MAXZOOM("options.worldmap.maxzoom", true, false, false),
     CACHESIZE("options.worldmap.cachesize", true, false, false),
     MOVEMAPDOWNWHILESTATSUEFFECT("options.minimap.movemapdownwhilestatuseffect", false, true, false),
-    MOVESCOREBOARDDOWN("options.minimap.movescoreboarddown", false, true, false);
+    MOVESCOREBOARDDOWN("options.minimap.movescoreboarddown", false, true, false),
+    DISTANCEUNITCONVERSION("options.minimap.waypoints.distanceunitconversion", false, true, false),
+    WAYPOINTNAMEBELOWICON("options.minimap.waypoints.waypointnamebelowicon", false, true, false);
 
     private final boolean isFloat;
     private final boolean isBoolean;

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/GuiSlotMinimap.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/GuiSlotMinimap.java
@@ -48,16 +48,19 @@ public abstract class GuiSlotMinimap extends AbstractSelectionList {
 
 
         if (this.showSlotBG) {
+            // I don't know much about OpenGL code :(
+            // If this code is weird, please fix it.
+
             OpenGL.glEnable(OpenGL.GL11_GL_BLEND);
             RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 0, 1);
             RenderSystem.setShader(CoreShaders.POSITION_COLOR);
-
+            RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
             float f = 32.0f;
             BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(this.getX() / f, (bottom + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(this.getRight() / f, (bottom + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(this.getRight() / f, (this.getY() + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(this.getX() / f, (this.getY() + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(0.0F, 0.0F).setColor(0, 0, 0, 127);
 
             BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
         }
@@ -71,36 +74,38 @@ public abstract class GuiSlotMinimap extends AbstractSelectionList {
         OpenGL.glDisable(OpenGL.GL11_GL_DEPTH_TEST);
 
         //byte topBottomFadeHeight = 4;
+        byte separatorHeight = 2;
 
         if (this.showTopBottomBG) {
+            // I don't know much about OpenGL code :(
+            // If this code is weird, please fix it.
+
+            // header separator
             OpenGL.glEnable(OpenGL.GL11_GL_BLEND);
             RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 0, 1);
-            RenderSystem.setShader(CoreShaders.POSITION_COLOR);
+            RenderSystem.setShader(CoreShaders.POSITION_TEX_COLOR);
+            RenderSystem.setShaderTexture(0, VoxelConstants.getOptionsSeparatorHeader());
+            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
 
-            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-            // white bar top
-            vertexBuffer.addVertex(this.getX(), this.getY() + 1, 0.0F).setUv(0.0F, 1.0F).setColor(255, 255, 255, 84);
-            vertexBuffer.addVertex(this.getRight(), this.getY() + 1, 0.0F).setUv(1.0F, 1.0F).setColor(255, 255, 255, 84);
-            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(1.0F, 0.0F).setColor(255, 255, 255, 84);
-            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(0.0F, 0.0F).setColor(255, 255, 255, 84);
+            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(0.0F, 1.0F).setColor(255, 255, 255, 255);
+            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(getWidth() / 32.0F, 1.0F).setColor(255, 255, 255, 255);
+            vertexBuffer.addVertex(this.getRight(), this.getY() - separatorHeight, 0.0F).setUv(getWidth() / 32.0F, 0.0F).setColor(255, 255, 255, 255);
+            vertexBuffer.addVertex(this.getX(), this.getY() - separatorHeight, 0.0F).setUv(0.0F, 0.0F).setColor(255, 255, 255, 255);
 
-            // white bar bottom
-            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(0.0F, 1.0F).setColor(255, 255, 255, 84);
-            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(1.0F, 1.0F).setColor(255, 255, 255, 84);
-            vertexBuffer.addVertex(this.getRight(), bottom - 1, 0.0F).setUv(1.0F, 0.0F).setColor(255, 255, 255, 84);
-            vertexBuffer.addVertex(this.getX(), bottom - 1, 0.0F).setUv(0.0F, 0.0F).setColor(255, 255, 255, 84);
+            BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
 
-            // black bar top
-            vertexBuffer.addVertex(this.getX(), this.getY() + 2, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getRight(), this.getY() + 2, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getRight(), this.getY() + 1, 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getX(), this.getY() + 1, 0.0F).setUv(0.0F, 0.0F).setColor(0, 0, 0, 127);
 
-            // black bar bottom
-            vertexBuffer.addVertex(this.getX(), bottom - 1, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getRight(), bottom - 1, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getRight(), bottom - 2, 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 127);
-            vertexBuffer.addVertex(this.getX(), bottom - 2, 0.0F).setUv(0.0F, 0.0F).setColor(0, 0, 0, 127);
+            // footer separator
+            OpenGL.glEnable(OpenGL.GL11_GL_BLEND);
+            RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 0, 1);
+            RenderSystem.setShader(CoreShaders.POSITION_TEX_COLOR);
+            RenderSystem.setShaderTexture(0, VoxelConstants.getOptionsSeparatorFooter());
+            vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
+
+            vertexBuffer.addVertex(this.getX(), bottom + separatorHeight, 0.0F).setUv(0.0F, 1.0F).setColor(255, 255, 255, 255);
+            vertexBuffer.addVertex(this.getRight(), bottom + separatorHeight, 0.0F).setUv(getWidth() / 32.0F, 1.0F).setColor(255, 255, 255, 255);
+            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(getWidth() / 32.0F, 0.0F).setColor(255, 255, 255, 255);
+            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(0.0F, 0.0F).setColor(255, 255, 255, 255);
 
             BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
         }

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/GuiSlotMinimap.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/GuiSlotMinimap.java
@@ -50,11 +50,10 @@ public abstract class GuiSlotMinimap extends AbstractSelectionList {
         if (this.showSlotBG) {
             OpenGL.glEnable(OpenGL.GL11_GL_BLEND);
             RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 0, 1);
-            RenderSystem.setShader(CoreShaders.POSITION_TEX_COLOR);
-            RenderSystem.setShaderTexture(0, VoxelConstants.getOptionsBackgroundTexture());
+            RenderSystem.setShader(CoreShaders.POSITION_COLOR);
 
             float f = 32.0f;
-            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
+            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
             vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(this.getX() / f, (bottom + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
             vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(this.getRight() / f, (bottom + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
             vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(this.getRight() / f, (this.getY() + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
@@ -71,23 +70,37 @@ public abstract class GuiSlotMinimap extends AbstractSelectionList {
         renderListItems(drawContext, mouseX, mouseY, delta);
         OpenGL.glDisable(OpenGL.GL11_GL_DEPTH_TEST);
 
-        byte topBottomFadeHeight = 4;
+        //byte topBottomFadeHeight = 4;
 
         if (this.showTopBottomBG) {
             OpenGL.glEnable(OpenGL.GL11_GL_BLEND);
             RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 0, 1);
-            RenderSystem.setShader(CoreShaders.POSITION_TEX_COLOR);
-            RenderSystem.setShaderTexture(0, VoxelConstants.getOptionsBackgroundTexture());
+            RenderSystem.setShader(CoreShaders.POSITION_COLOR);
 
-            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
-            vertexBuffer.addVertex(this.getX(), this.getY() + topBottomFadeHeight, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 0);
-            vertexBuffer.addVertex(this.getRight(), this.getY() + topBottomFadeHeight, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 0);
-            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 255);
-            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(0.0F, 0.0F).setColor(0, 0, 0, 255);
-            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 255);
-            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 255);
-            vertexBuffer.addVertex(this.getRight(), bottom - topBottomFadeHeight, 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 0);
-            vertexBuffer.addVertex(this.getX(), bottom - topBottomFadeHeight, 0.0F).setUv(0.0F, 0.0F).setColor(0, 0, 0, 0);
+            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+            // white bar top
+            vertexBuffer.addVertex(this.getX(), this.getY() + 1, 0.0F).setUv(0.0F, 1.0F).setColor(255, 255, 255, 84);
+            vertexBuffer.addVertex(this.getRight(), this.getY() + 1, 0.0F).setUv(1.0F, 1.0F).setColor(255, 255, 255, 84);
+            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(1.0F, 0.0F).setColor(255, 255, 255, 84);
+            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(0.0F, 0.0F).setColor(255, 255, 255, 84);
+
+            // white bar bottom
+            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(0.0F, 1.0F).setColor(255, 255, 255, 84);
+            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(1.0F, 1.0F).setColor(255, 255, 255, 84);
+            vertexBuffer.addVertex(this.getRight(), bottom - 1, 0.0F).setUv(1.0F, 0.0F).setColor(255, 255, 255, 84);
+            vertexBuffer.addVertex(this.getX(), bottom - 1, 0.0F).setUv(0.0F, 0.0F).setColor(255, 255, 255, 84);
+
+            // black bar top
+            vertexBuffer.addVertex(this.getX(), this.getY() + 2, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), this.getY() + 2, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), this.getY() + 1, 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getX(), this.getY() + 1, 0.0F).setUv(0.0F, 0.0F).setColor(0, 0, 0, 127);
+
+            // black bar bottom
+            vertexBuffer.addVertex(this.getX(), bottom - 1, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), bottom - 1, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), bottom - 2, 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getX(), bottom - 2, 0.0F).setUv(0.0F, 0.0F).setColor(0, 0, 0, 127);
 
             BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
         }

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/GuiSlotMinimap.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/overridden/GuiSlotMinimap.java
@@ -48,15 +48,17 @@ public abstract class GuiSlotMinimap extends AbstractSelectionList {
 
 
         if (this.showSlotBG) {
+            OpenGL.glEnable(OpenGL.GL11_GL_BLEND);
+            RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 0, 1);
             RenderSystem.setShader(CoreShaders.POSITION_TEX_COLOR);
             RenderSystem.setShaderTexture(0, VoxelConstants.getOptionsBackgroundTexture());
-            RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+
             float f = 32.0f;
             BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
-            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(this.getX() / f, (bottom + (int) scrollAmount()) / f).setColor(32, 32, 32, 255);
-            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(this.getRight() / f, (bottom + (int) scrollAmount()) / f).setColor(32, 32, 32, 255);
-            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(this.getRight() / f, (this.getY() + (int) scrollAmount()) / f).setColor(32, 32, 32, 255);
-            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(this.getX() / f, (this.getY() + (int) scrollAmount()) / f).setColor(32, 32, 32, 255);
+            vertexBuffer.addVertex(this.getX(), bottom, 0.0F).setUv(this.getX() / f, (bottom + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), bottom, 0.0F).setUv(this.getRight() / f, (bottom + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(this.getRight() / f, (this.getY() + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
+            vertexBuffer.addVertex(this.getX(), this.getY(), 0.0F).setUv(this.getX() / f, (this.getY() + (int) scrollAmount()) / f).setColor(0, 0, 0, 127);
 
             BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
         }
@@ -72,31 +74,12 @@ public abstract class GuiSlotMinimap extends AbstractSelectionList {
         byte topBottomFadeHeight = 4;
 
         if (this.showTopBottomBG) {
-            RenderSystem.setShader(CoreShaders.POSITION_TEX_COLOR);
-            RenderSystem.setShaderTexture(0, VoxelConstants.getOptionsBackgroundTexture());
-            RenderSystem.enableDepthTest();
-            RenderSystem.depthFunc(OpenGL.GL11_GL_ALWAYS);
-
-            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
-            vertexBuffer.addVertex(this.getX(), this.getY(), -100.0F).setUv(0.0F, this.getY() / 32.0F).setColor(64, 64, 64, 255);
-            vertexBuffer.addVertex(this.getX() + width, this.getY(), -100.0F).setUv(width / 32.0F, this.getY() / 32.0F).setColor(64, 64, 64, 255);
-            vertexBuffer.addVertex(this.getX() + width, 0.0F, -100.0F).setUv(width / 32.0F, 0.0F).setColor(64, 64, 64, 255);
-            vertexBuffer.addVertex(this.getX(), 0.0F, -100.0F).setUv(0.0F, 0.0F).setColor(64, 64, 64, 255);
-            vertexBuffer.addVertex(this.getX(), fullheight, -100.0F).setUv(0.0F, fullheight / 32.0F).setColor(64, 64, 64, 255);
-            vertexBuffer.addVertex(this.getX() + width, fullheight, -100.0F).setUv(width / 32.0F, fullheight / 32.0F).setColor(64, 64, 64, 255);
-            vertexBuffer.addVertex(this.getX() + width, bottom, -100.0F).setUv(width / 32.0F, bottom / 32.0F).setColor(64, 64, 64, 255);
-            vertexBuffer.addVertex(this.getX(), bottom, -100.0F).setUv(0.0F, bottom / 32.0F).setColor(64, 64, 64, 255);
-
-            BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
-
-            RenderSystem.depthFunc(OpenGL.GL11_GL_LEQUAL);
-            RenderSystem.disableDepthTest();
             OpenGL.glEnable(OpenGL.GL11_GL_BLEND);
             RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 0, 1);
             RenderSystem.setShader(CoreShaders.POSITION_TEX_COLOR);
             RenderSystem.setShaderTexture(0, VoxelConstants.getOptionsBackgroundTexture());
 
-            vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
+            BufferBuilder vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
             vertexBuffer.addVertex(this.getX(), this.getY() + topBottomFadeHeight, 0.0F).setUv(0.0F, 1.0F).setColor(0, 0, 0, 0);
             vertexBuffer.addVertex(this.getRight(), this.getY() + topBottomFadeHeight, 0.0F).setUv(1.0F, 1.0F).setColor(0, 0, 0, 0);
             vertexBuffer.addVertex(this.getRight(), this.getY(), 0.0F).setUv(1.0F, 0.0F).setColor(0, 0, 0, 255);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/persistent/GuiPersistentMap.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/persistent/GuiPersistentMap.java
@@ -861,11 +861,11 @@ public class GuiPersistentMap extends PopupGuiScreen implements IGuiWaypoints {
             int scHeight = VoxelConstants.getMinecraft().getWindow().getGuiScaledHeight();
             RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.setShader(CoreShaders.POSITION_TEX);
-            ResourceLocation GUI_ICONS_TEXTURE = ResourceLocation.parse("textures/gui/icons.png");
+            ResourceLocation GUI_ICONS_TEXTURE = ResourceLocation.parse("textures/gui/sprites/hud/crosshair.png");
             RenderSystem.setShaderTexture(0, GUI_ICONS_TEXTURE);
             RenderSystem.enableBlend();
             RenderSystem.blendFuncSeparate(775, 769, 1, 0);
-            drawContext.blit(RenderType::guiTextured, GUI_ICONS_TEXTURE, scWidth / 2 - 7, scHeight / 2 - 7, 0, 0, 16, 16, 256, 256);
+            drawContext.blit(RenderType::guiTextured, GUI_ICONS_TEXTURE, scWidth / 2 - 7, scHeight / 2 - 7, 0, 0, 15, 15, 15, 15);
             drawContext.flush();
             RenderSystem.blendFuncSeparate(OpenGL.GL11_GL_SRC_ALPHA, OpenGL.GL11_GL_ONE_MINUS_SRC_ALPHA, 1, 0);
         } else {

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/persistent/GuiPersistentMapOptions.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/persistent/GuiPersistentMapOptions.java
@@ -102,7 +102,8 @@ public class GuiPersistentMapOptions extends GuiScreenMinimap {
             }
         }
 
-        this.renderTransparentBackground(drawContext);
+        this.renderBlurredBackground();
+        this.renderMenuBackground(drawContext);
         drawContext.flush();
         drawContext.drawCenteredString(this.getFontRenderer(), this.screenTitle, this.getWidth() / 2, 20, 16777215);
         drawContext.drawCenteredString(this.getFontRenderer(), this.cacheSettings, this.getWidth() / 2, this.getHeight() / 6 + 24, 16777215);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/util/EnumMobs.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/util/EnumMobs.java
@@ -139,7 +139,7 @@ public enum EnumMobs {
     PIG(Pig.class, "Pig", true, 0.0F, "textures/entity/pig/pig.png", "", false, true),
     PIGLIN(Piglin.class, "Piglin", true, 0.0F, "textures/entity/piglin/piglin.png", "", true, false),
     PIGLINBRUTE(PiglinBrute.class, "Piglin_Brute", true, 0.0F, "textures/entity/piglin/piglin_brute.png", "", true, false),
-    PIGLINZOMBIE(ZombifiedPiglin.class, "Zombie_Piglin", true, 0.0F, "textures/entity/piglin/zombified_piglin.png", "", true, true),
+    PIGLINZOMBIE(ZombifiedPiglin.class, "Zombified_Piglin", true, 0.0F, "textures/entity/piglin/zombified_piglin.png", "", true, true),
     PILLAGER(Pillager.class, "Pillager", true, 0.0F, "textures/entity/illager/pillager.png", "", true, false),
     PLAYER(RemotePlayer.class, "Player", false, 8.0F, "textures/entity/steve.png", "", false, false),
     POLARBEAR(PolarBear.class, "Polar_Bear", true, 0.0F, "textures/entity/bear/polarbear.png", "", true, true),

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
@@ -189,8 +189,12 @@ public class WaypointContainer {
                 isPointedAt = false;
             }
         }
-
-        name = name + " (" + (int) distance + "m)";
+        if (this.options.distanceUnitConversion && distance > 10000.0){
+            name = name + " (" + Math.round(distance / 100.0) / 10.0 + "km)";
+        }
+        else {
+            name = name + " (" + Math.round(distance * 10.0) / 10.0 + "m)";
+        }
         double maxDistance = VoxelConstants.getMinecraft().options.simulationDistance().get() * 16.0 * 0.99;
         double adjustedDistance = distance;
         if (distance > maxDistance) {
@@ -245,7 +249,7 @@ public class WaypointContainer {
 
         Font fontRenderer = VoxelConstants.getMinecraft().font;
         if (isPointedAt && fontRenderer != null) {
-            byte elevateBy = -19;
+            byte elevateBy = options.waypointNameBelowIcon ? (byte) 10 : (byte) -19;
             OpenGL.glEnable(OpenGL.GL11_GL_POLYGON_OFFSET_FILL);
             int halfStringWidth = fontRenderer.width(name) / 2;
             RenderSystem.setShader(CoreShaders.POSITION_COLOR);

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
@@ -254,8 +254,8 @@ public class WaypointContainer {
         Font fontRenderer = VoxelConstants.getMinecraft().font;
         if (isPointedAt && fontRenderer != null) {
             byte elevateBy = this.options.waypointNameBelowIcon ? (byte) 10 : (byte) -19;
-            byte elevateDistBy = this.options.waypointNameBelowIcon ? (byte) 21 : (byte) -30;
-
+            byte elevateDistBy = this.options.waypointNameBelowIcon ? (byte) 30: (byte) -39;
+            float distTextScale = 0.65F;
             OpenGL.glEnable(OpenGL.GL11_GL_POLYGON_OFFSET_FILL);
             int halfStringWidth = fontRenderer.width(name) / 2;
             int halfDistStringWidth = fontRenderer.width(distStr) / 2;
@@ -279,6 +279,7 @@ public class WaypointContainer {
                 BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
 
                 if (this.options.waypointDistanceBelowName){
+                    matrixStack.scale(distTextScale);
                     OpenGL.glPolygonOffset(1.0F, 7.0F);
                     vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
                     vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 2), (-2 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
@@ -293,6 +294,7 @@ public class WaypointContainer {
                     vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (6 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
                     vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (-1 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
                     BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+                    matrixStack.scale(1.0F / distTextScale);
                 }
             }
 
@@ -315,6 +317,7 @@ public class WaypointContainer {
                 BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
 
                 if (this.options.waypointDistanceBelowName){
+                    matrixStack.scale(distTextScale);
                     OpenGL.glPolygonOffset(1.0F, 11.0F);
                     vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
                     vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 2), (-2 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
@@ -329,6 +332,7 @@ public class WaypointContainer {
                     vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (6 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
                     vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (-1 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
                     BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+                    matrixStack.scale(1.0F / distTextScale);
                 }
             }
 
@@ -340,7 +344,9 @@ public class WaypointContainer {
                 OpenGL.glDisable(OpenGL.GL11_GL_DEPTH_TEST);
                 fontRenderer.drawInBatch(Component.literal(name), (-fontRenderer.width(name) / 2f), elevateBy, textColor, false, matrixStack, vertexConsumerProvider, DisplayMode.SEE_THROUGH, 0, 15728880);
                 if (this.options.waypointDistanceBelowName){
+                    matrixStack.scale(distTextScale);
                     fontRenderer.drawInBatch(Component.literal(distStr), (-fontRenderer.width(distStr) / 2f), elevateDistBy, textColor, false, matrixStack, vertexConsumerProvider, DisplayMode.SEE_THROUGH, 0, 15728880);
+                    matrixStack.scale(1.0F / distTextScale);
                 }
                 vertexConsumerProvider.endBatch();
             }

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
@@ -189,11 +189,15 @@ public class WaypointContainer {
                 isPointedAt = false;
             }
         }
+        String distStr;
         if (this.options.distanceUnitConversion && distance > 10000.0){
-            name = name + " (" + Math.round(distance / 100.0) / 10.0 + "km)";
+            distStr = (Math.round(distance / 100.0) / 10.0) + "km";
         }
         else {
-            name = name + " (" + Math.round(distance * 10.0) / 10.0 + "m)";
+            distStr = (Math.round(distance * 10.0) / 10.0) + "m";
+        }
+        if (!this.options.waypointDistanceBelowName){
+            name = name + " (" + distStr + ")";
         }
         double maxDistance = VoxelConstants.getMinecraft().options.simulationDistance().get() * 16.0 * 0.99;
         double adjustedDistance = distance;
@@ -249,9 +253,12 @@ public class WaypointContainer {
 
         Font fontRenderer = VoxelConstants.getMinecraft().font;
         if (isPointedAt && fontRenderer != null) {
-            byte elevateBy = options.waypointNameBelowIcon ? (byte) 10 : (byte) -19;
+            byte elevateBy = this.options.waypointNameBelowIcon ? (byte) 10 : (byte) -19;
+            byte elevateDistBy = this.options.waypointNameBelowIcon ? (byte) 21 : (byte) -30;
+
             OpenGL.glEnable(OpenGL.GL11_GL_POLYGON_OFFSET_FILL);
             int halfStringWidth = fontRenderer.width(name) / 2;
+            int halfDistStringWidth = fontRenderer.width(distStr) / 2;
             RenderSystem.setShader(CoreShaders.POSITION_COLOR);
             if (withDepth) {
                 OpenGL.glEnable(OpenGL.GL11_GL_DEPTH_TEST);
@@ -270,6 +277,23 @@ public class WaypointContainer {
                 vertexBuffer.addVertex(matrixStack, (halfStringWidth + 1), (8 + elevateBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.15F * fade);
                 vertexBuffer.addVertex(matrixStack, (halfStringWidth + 1), (-1 + elevateBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.15F * fade);
                 BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+
+                if (this.options.waypointDistanceBelowName){
+                    OpenGL.glPolygonOffset(1.0F, 7.0F);
+                    vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 2), (-2 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 2), (7 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 2), (7 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 2), (-2 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+                    OpenGL.glPolygonOffset(1.0F, 5.0F);
+                    vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 1), (-1 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 1), (6 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (6 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (-1 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+                }
             }
 
             if (withoutDepth) {
@@ -289,6 +313,23 @@ public class WaypointContainer {
                 vertexBuffer.addVertex(matrixStack, (halfStringWidth + 1), (8 + elevateBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.15F * fade);
                 vertexBuffer.addVertex(matrixStack, (halfStringWidth + 1), (-1 + elevateBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.15F * fade);
                 BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+
+                if (this.options.waypointDistanceBelowName){
+                    OpenGL.glPolygonOffset(1.0F, 11.0F);
+                    vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 2), (-2 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 2), (7 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 2), (7 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 2), (-2 + elevateDistBy), 0.0F).setColor(0.0F, 0.0F, 0.0F, 0.6F * fade);
+                    BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+                    OpenGL.glPolygonOffset(1.0F, 9.0F);
+                    vertexBuffer = tessellator.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 1), (-1 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    vertexBuffer.addVertex(matrixStack, (-halfDistStringWidth - 1), (6 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (6 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    vertexBuffer.addVertex(matrixStack, (halfDistStringWidth + 1), (-1 + elevateDistBy), 0.0F).setColor(1.0F, 1.0F, 1.0F, 0.15F * fade);
+                    BufferUploader.drawWithShader(vertexBuffer.buildOrThrow());
+                }
             }
 
             OpenGL.glDisable(OpenGL.GL11_GL_POLYGON_OFFSET_FILL);
@@ -298,6 +339,9 @@ public class WaypointContainer {
                 int textColor = (int) (255.0F * fade) << 24 | 13421772;
                 OpenGL.glDisable(OpenGL.GL11_GL_DEPTH_TEST);
                 fontRenderer.drawInBatch(Component.literal(name), (-fontRenderer.width(name) / 2f), elevateBy, textColor, false, matrixStack, vertexConsumerProvider, DisplayMode.SEE_THROUGH, 0, 15728880);
+                if (this.options.waypointDistanceBelowName){
+                    fontRenderer.drawInBatch(Component.literal(distStr), (-fontRenderer.width(distStr) / 2f), elevateDistBy, textColor, false, matrixStack, vertexConsumerProvider, DisplayMode.SEE_THROUGH, 0, 15728880);
+                }
                 vertexConsumerProvider.endBatch();
             }
 

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/util/WaypointContainer.java
@@ -193,7 +193,10 @@ public class WaypointContainer {
         if (this.options.distanceUnitConversion && distance > 10000.0){
             distStr = (Math.round(distance / 100.0) / 10.0) + "km";
         }
-        else {
+        else if (distance >= 9999999.0F) {
+            distStr = (int) distance  + "m";
+        }
+        else{
             distStr = (Math.round(distance * 10.0) / 10.0) + "m";
         }
         if (!this.options.waypointDistanceBelowName){

--- a/common/src/main/resources/assets/voxelmap/lang/en_us.json
+++ b/common/src/main/resources/assets/voxelmap/lang/en_us.json
@@ -81,6 +81,7 @@
   "options.minimap.waypoints.showwaypointnames": "Point Names on Map",
   "options.minimap.waypoints.distanceunitconversion": "Distance Unit Conversion",
   "options.minimap.waypoints.waypointnamebelowicon": "Waypoint Name Below Icon",
+  "options.minimap.waypoints.waypointdistancebelowname": "Distance Text Below Name",
   "options.minimap.mobs.title": "Show or Hide Individual Mob Types",
   "options.minimap.mobs.enable": "Enable Mob Icon",
   "options.minimap.mobs.disable": "Disable Mob Icon",

--- a/common/src/main/resources/assets/voxelmap/lang/en_us.json
+++ b/common/src/main/resources/assets/voxelmap/lang/en_us.json
@@ -79,6 +79,8 @@
   "options.minimap.waypoints.deathpoints.all": "All",
   "options.minimap.waypoints.deathpoints.tooltip": "Takes effect on next death",
   "options.minimap.waypoints.showwaypointnames": "Point Names on Map",
+  "options.minimap.waypoints.distanceunitconversion": "Distance Unit Conversion",
+  "options.minimap.waypoints.waypointnamebelowicon": "Waypoint Name Below Icon",
   "options.minimap.mobs.title": "Show or Hide Individual Mob Types",
   "options.minimap.mobs.enable": "Enable Mob Icon",
   "options.minimap.mobs.disable": "Disable Mob Icon",

--- a/common/src/main/resources/assets/voxelmap/lang/en_us.json
+++ b/common/src/main/resources/assets/voxelmap/lang/en_us.json
@@ -120,6 +120,7 @@
   "minimap.waypoints.sortbycreated": "Created",
   "minimap.waypoints.sortbycolor": "Color ",
   "minimap.waypoints.sortbyicon": "Icon",
+  "minimap.waypoints.add": "Add",
   "minimap.waypointshare.title": "Share Waypoint",
   "minimap.waypointshare.titlecoordinate": "Share Coordinate",
   "minimap.waypointshare.sharemessage": "Add Message (optional)",

--- a/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
+++ b/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
@@ -70,7 +70,7 @@
   "options.minimap.worldborder": "월드보더",
   "options.minimap.worldseed": "시드",
   "options.minimap.teleportcommand": "순간이동 명령어",
-  "options.minimap.waypoints": "웨이포인트 설정...",
+  "options.minimap.waypoints": "웨이포인트...",
   "options.minimap.waypoints.title": "웨이포인트 설정",
   "options.minimap.waypoints.distance": "최대 거리",
   "options.minimap.waypoints.infinite": "무제한",

--- a/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
+++ b/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
@@ -120,6 +120,7 @@
   "minimap.waypoints.sortbycreated": "날짜",
   "minimap.waypoints.sortbycolor": "색상",
   "minimap.waypoints.sortbyicon": "아이콘",
+  "minimap.waypoints.add": "추가",
   "minimap.waypointshare.title": "웨이포인트 공유",
   "minimap.waypointshare.titlecoordinate": "좌표 공유",
   "minimap.waypointshare.sharemessage": "메시지 추가 (선택)",

--- a/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
+++ b/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
@@ -79,6 +79,8 @@
   "options.minimap.waypoints.deathpoints.all": "전부",
   "options.minimap.waypoints.deathpoints.tooltip": "다음 사망 시 적용됩니다",
   "options.minimap.waypoints.showwaypointnames": "미니맵에 웨이포인트 이름 표시",
+  "options.minimap.waypoints.distanceunitconversion": "거리 단위 변환 사용",
+  "options.minimap.waypoints.waypointnamebelowicon": "아이콘 아래에 이름 배치",
   "options.minimap.mobs.title": "개별 몹 유형 표시/숨기기",
   "options.minimap.mobs.enable": "몹 아이콘 표시",
   "options.minimap.mobs.disable": "몹 아이콘 숨기기",

--- a/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
+++ b/common/src/main/resources/assets/voxelmap/lang/ko_kr.json
@@ -81,6 +81,7 @@
   "options.minimap.waypoints.showwaypointnames": "미니맵에 웨이포인트 이름 표시",
   "options.minimap.waypoints.distanceunitconversion": "거리 단위 변환 사용",
   "options.minimap.waypoints.waypointnamebelowicon": "아이콘 아래에 이름 배치",
+  "options.minimap.waypoints.waypointdistancebelowname": "이름 아래에 거리 텍스트 배치",
   "options.minimap.mobs.title": "개별 몹 유형 표시/숨기기",
   "options.minimap.mobs.enable": "몹 아이콘 표시",
   "options.minimap.mobs.disable": "몹 아이콘 숨기기",


### PR DESCRIPTION
There is a bug in NeoForge where it crashes when you open the Waypoint window or the Mob Selection window.
This is not a problem with my code, it is a problem with the source code itself :)
And the issue of the waypoint window turning red when a waypoint is highlighted is also a problem within the source code itself.

# Overall Changes
- Clear and Blurred Menu Background

# Waypoints
- Replace/Renamed New Waypoints button.
(New Waypoints -> Add)
![2024-12-13_18 23 21](https://github.com/user-attachments/assets/7cd6ea7d-3438-4573-8630-33dee995bebe)

# Add Waypoints
- Replaced the placeholders from XZY to XYZ
![NewGUI_AddWaypoints](https://github.com/user-attachments/assets/5f834de1-39bf-4332-b4d7-6e5720be4e4c)

# Radar and Others
- Mobs To Display... button moved
- Toggles has been replaced
![NewGUI_Radaretc](https://github.com/user-attachments/assets/c2300d31-208d-4738-874b-0b320f5aec5c)

# Mob Selection
- Clear And Blurry Background
![2024-12-13_18 23 27](https://github.com/user-attachments/assets/61d4d003-a441-4798-a110-77301d16aa52)

# In-Game Waypoints
- Added some features to Waypoint Options.
![WaypointOptionsWindow](https://github.com/user-attachments/assets/2f945f0e-e412-400a-8e1f-1eb698130cf2)

- Examples of new options
Distance Unit Conversion : If the distance is over 10,000 meters, convert the units from meters to kilometers.
![Example](https://github.com/user-attachments/assets/0a293580-5b96-48d6-acfe-d7b920e89106)


# Old GUIs
I've attached some old GUI images for comparison
- Waypoints
![OldGUI_Waypoints](https://github.com/user-attachments/assets/8bef0ea7-35b2-4b7c-b76c-5f8ad71bf7a9)
- Add waypoints
![OldGUI_AddWaypoints](https://github.com/user-attachments/assets/195faf4b-7492-49ad-be79-1207c59f59f2)
- Radar options
![OldGUI_Radaretc](https://github.com/user-attachments/assets/2bba8eea-d096-48ef-9b16-4500a05562dc)
- Mob selection
![OldGUI_DisplayMobs](https://github.com/user-attachments/assets/d0b62a94-9063-4229-9774-1b5e15fb8f6f)
